### PR TITLE
contracts/MonethaToken: Only allow crowdsale contract to `burn()`

### DIFF
--- a/contracts/Crowdsale.sol
+++ b/contracts/Crowdsale.sol
@@ -150,8 +150,8 @@ contract Crowdsale is SafeMath {
 
 	/* checks if the goal or time limit has been reached and ends the campaign */
 	function checkGoalReached() afterDeadline {
+		tokenReward.burn(); //burn remaining tokens but the reserved ones
 		if (tokensSold >= fundingGoal) {
-			tokenReward.burn(); //burn remaining tokens but the reserved ones
 			GoalReached(beneficiary, amountRaised);
 		}
 		crowdsaleClosed = true;

--- a/contracts/MonethaToken.sol
+++ b/contracts/MonethaToken.sol
@@ -124,14 +124,15 @@ contract MonethaToken is SafeMath {
 	 *  anybody may burn the tokens after ICO ended, but only once (in case the owner holds more tokens in the future).
 	 *  this ensures that the owner will not posses a majority of the tokens. */
 	function burn() onlyICO {
+		require(!burned);
+
 		//if tokens have not been burned already and the ICO ended
-		if (!burned && now > startTime) {
-			uint difference = safeSub(balanceOf[owner], reservedAmount);
-			balanceOf[owner] = reservedAmount;
-			totalSupply = safeSub(totalSupply, difference);
-			burned = true;
-			Burned(difference);
-		}
+		uint difference = safeSub(balanceOf[owner], reservedAmount);
+		balanceOf[owner] = reservedAmount;
+		totalSupply = safeSub(totalSupply, difference);
+
+		burned = true;
+		Burned(difference);
 	}
 	
 	/**

--- a/contracts/MonethaToken.sol
+++ b/contracts/MonethaToken.sol
@@ -108,12 +108,22 @@ contract MonethaToken is SafeMath {
 		return true;
 	}
 
+	modifier onlyOwner() {
+		require(msg.sender == owner);
+		_;
+	}
+
+	modifier onlyICO() {
+		require(msg.sender == ico);
+		_;
+	}
+
 
 	/* to be called when ICO is closed. burns the remaining tokens except the company share (60360000), the tokens reserved
 	 *  for the bounty/advisors/marketing program (48288000), for the loyalty program (52312000) and for future financing of the company (40240000).
 	 *  anybody may burn the tokens after ICO ended, but only once (in case the owner holds more tokens in the future).
 	 *  this ensures that the owner will not posses a majority of the tokens. */
-	function burn() {
+	function burn() onlyICO {
 		//if tokens have not been burned already and the ICO ended
 		if (!burned && now > startTime) {
 			uint difference = safeSub(balanceOf[owner], reservedAmount);
@@ -129,8 +139,8 @@ contract MonethaToken is SafeMath {
 	* @param _icoAddress the address of the ico contract
 	* value the max amount of tokens to sell during the ICO
 	**/
-	function setICO(address _icoAddress) {
-		require(msg.sender == owner);
+	function setICO(address _icoAddress) onlyOwner {
+		require(ico == 0x0 && _icoAddress != 0x0);
 		ico = _icoAddress;
 		assert(_approve(ico, tokensForIco));
 	}
@@ -140,8 +150,8 @@ contract MonethaToken is SafeMath {
 	* (In case the soft cap has been reached)
 	* @param _newStart the new start date
 	**/
-	function setStart(uint _newStart) {
-		require(msg.sender == ico && _newStart < startTime);
+	function setStart(uint _newStart) onlyICO {
+		require(_newStart < startTime);
 		startTime = _newStart;
 	}
 

--- a/test/Token.js
+++ b/test/Token.js
@@ -25,6 +25,20 @@ contract('token', accounts => {
     assert.equal(startTime, start);
   });
 
+  it("should fail to change the start time", async() => {
+    try {
+      let result = await instance.setStart(10000);
+      throw new Error('Promise was unexpectedly fulfilled. Result: ' + result);
+    } catch (error) {
+      let startTime = await instance.startTime();
+      assert.equal(startTime, start);
+    }
+  });
+
+  it("should set an ico address", async() => {
+    await instance.setICO(accounts[0]);
+  });
+
   it("should allow acc1 to spend 10MTH", async() => {
     let result = await instance.approve(accounts[1], 1000000);
     let event = result.logs[0].args;
@@ -149,18 +163,7 @@ contract('token', accounts => {
     }
   });
 
-  it("should fail to change the start time", async() => {
-    try {
-      let result = await instance.setStart(10000);
-      throw new Error('Promise was unexpectedly fulfilled. Result: ' + result);
-    } catch (error) {
-      let startTime = await instance.startTime();
-      assert.equal(startTime, start);
-    }
-  });
-
-  it("should set an ico address and change the start time", async() => {
-    await instance.setICO(accounts[0]);
+  it("should change the start time", async() => {
     await instance.setStart(1506770000);
     let startTime = await instance.startTime();
     assert.equal(startTime, 1506770000);


### PR DESCRIPTION
Could potentially make the crowdsale to never finish and toggle `crowdsaleClosed`.

Explicitly disallow setting `ico` multiple times.